### PR TITLE
Tomcat swallows System.err output

### DIFF
--- a/tomcat-logging-support/pom.xml
+++ b/tomcat-logging-support/pom.xml
@@ -36,6 +36,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tomcat-logging-support/src/test/java/com/gopivotal/cloudfoundry/tomcat/logging/CloudFoundryConsoleHandlerTest.java
+++ b/tomcat-logging-support/src/test/java/com/gopivotal/cloudfoundry/tomcat/logging/CloudFoundryConsoleHandlerTest.java
@@ -16,13 +16,37 @@
 
 package com.gopivotal.cloudfoundry.tomcat.logging;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+
+import java.io.PrintStream;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public final class CloudFoundryConsoleHandlerTest {
 
+    private final PrintStream mockErr = mock(PrintStream.class);
+
+    private PrintStream savedErr = System.err;
+
+    @Before
+    public void before() {
+        this.savedErr = System.err;
+    }
+
+    @After
+    public void after() {
+        System.setErr(this.savedErr);
+    }
+
     @Test
-    public void test() {
+    public void test() throws NoSuchFieldException, IllegalAccessException {
+        System.setErr(this.mockErr);
         new CloudFoundryConsoleHandler();
+        verify(this.mockErr, times(0)).close();
     }
 
 }


### PR DESCRIPTION
When Tomcat starts up we set the ConsoleHandlers output stream to System.out in
our custom sub-class. The default is System.err and the ConsoleHandler will call
close on it when replacing it with System.out. This commit ensures that the
ConsoleHandler does not call close on the existing output stream by reflectively
nulling it first.

[#80445246]
