### PR TITLE
Added null check prior to accessing logger name.

### DIFF
--- a/tomcat-logging-support/src/main/java/com/gopivotal/cloudfoundry/tomcat/logging/CloudFoundryFormatter.java
+++ b/tomcat-logging-support/src/main/java/com/gopivotal/cloudfoundry/tomcat/logging/CloudFoundryFormatter.java
@@ -52,7 +52,7 @@ public final class CloudFoundryFormatter extends Formatter {
     private String getLogger(LogRecord record) {
         String loggerName = record.getLoggerName();
 
-        if (loggerName.length() > MAX_LENGTH) {
+        if (loggerName != null && loggerName.length() > MAX_LENGTH) {
             return loggerName.substring(loggerName.length() - MAX_LENGTH);
         }
 

--- a/tomcat-logging-support/src/test/java/com/gopivotal/cloudfoundry/tomcat/logging/CloudFoundryFormatterTest.java
+++ b/tomcat-logging-support/src/test/java/com/gopivotal/cloudfoundry/tomcat/logging/CloudFoundryFormatterTest.java
@@ -73,5 +73,13 @@ public final class CloudFoundryFormatterTest {
         assertEquals("[CONTAINER] short.logger                                       INFO    Test Message " +
                 "parameter-1\n", this.formatter.format(record));
     }
+    
+    @Test
+    public void nullLoggerName() {
+    	LogRecord record = new LogRecord(Level.INFO, "Message OK");
+    	
+    	assertEquals("[CONTAINER] null                                               INFO    Message OK\n",
+    			this.formatter.format(record));
+    }
 
 }


### PR DESCRIPTION
Working with a legacy & proprietary app deployed as a WAR file on CF and it appears that the logger name is null.  This is throwing a NPE.

```
2015-07-01T12:01:51.42+0100 [App/0] ERR java.lang.NullPointerException 
2015-07-01T12:01:51.42+0100 [App/0] ERR at com.gopivotal.cloudfoundry.tomcat.logging.CloudFoundryFormatter.getLogger(CloudFoundryFormatter.java:55) 
2015-07-01T12:01:51.42+0100 [App/0] ERR at com.gopivotal.cloudfoundry.tomcat.logging.CloudFoundryFormatter.format(CloudFoundryFormatter.java:35) 
2015-07-01T12:01:51.42+0100 [App/0] ERR at java.util.logging.StreamHandler.publish(StreamHandler.java:211) 
2015-07-01T12:01:51.42+0100 [App/0] ERR at java.util.logging.ConsoleHandler.publish(ConsoleHandler.java:116) 
2015-07-01T12:01:51.42+0100 [App/0] ERR at java.util.logging.Logger.log(Logger.java:738) 
...
```

Seems like a null check should be done first as null is a legit return value from LogRecord.getLoggerName() [javadocs](http://docs.oracle.com/javase/7/docs/api/java/util/logging/LogRecord.html#getLoggerName()).

Thanks!