### PR TITLE
prevent creation of empty access log files

### DIFF
--- a/tomcat-access-logging-support/src/main/java/org/cloudfoundry/tomcat/logging/access/CloudFoundryAccessLoggingValve.java
+++ b/tomcat-access-logging-support/src/main/java/org/cloudfoundry/tomcat/logging/access/CloudFoundryAccessLoggingValve.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,4 +38,8 @@ public final class CloudFoundryAccessLoggingValve extends AccessLogValve {
         System.out.println(message);
     }
 
+    @Override
+    protected synchronized void open() {
+        // ignore
+    }
 }


### PR DESCRIPTION
Provide empty implementation for `open` method of `AccessLogValve` to prevent creation of unused files.
This allows using the lib with a readonly filesystem for increased security.

See also: https://github.com/paketo-buildpacks/apache-tomee/issues/107